### PR TITLE
Adjust completion time to correct timezone

### DIFF
--- a/library/class.teamwork.php
+++ b/library/class.teamwork.php
@@ -308,7 +308,7 @@ class Teamwork {
 
             if ($task['completed']) {
                 $taskCompletedDate = Teamwork::time($task['completed_on']);
-                $taskCompletedKey = $taskCompletedDate->format('Ymd');
+                $taskCompletedKey = $taskCompletedDate->setTimezone(new DateTimeZone('America/New_York'))->format('Ymd');
 
                 // Task was completed in a previous sprint
                 if ($taskCompletedDate < $startDate) {


### PR DESCRIPTION
Probably moves the day boundary to midnight for completed tasks. Except Friday, but I'm over it.
