### PR TITLE
Fix the burndown chart caused by a TW API change

### DIFF
--- a/library/class.teamwork.php
+++ b/library/class.teamwork.php
@@ -188,6 +188,14 @@ class Teamwork {
 
         if ($completed) {
             $request->parameter('includeCompletedTasks', true);
+
+            // Without the parameter "ignore-start-dates", the API started returning a list unfiltered by the specified dates.
+            // All completed tasks had a "start_date" prior to interval selected and an empty "due-date".
+            // All incomplete tasks had an empty "start_date" and a valid "due-date" in the interval selected.
+            //
+            // Setting the request parameter "ignore-start-dates" to true appears to solve this issue.
+            // Now the list of completed and incomplete tasks have the same characteristics which is, they have an empty "start_date" and a valid "due-date".
+            $request->parameter('ignore-start-dates', true);
         }
 
         $request->cache(3600);

--- a/settings/about.php
+++ b/settings/about.php
@@ -9,9 +9,10 @@
  * @changes
  *  1.0.2       Switch to activedial.js instead of activebar.js to fix the high cpu usage on MacBook.
  *  1.1         Change the graph library from Elycharts to C3
+ *  1.1.1       Fix the burndown chart caused by a TeamWork API change
  *
  * @author Tim Gunter <tim@vanillaforums.com>
- * @copyright 2010-2014 Vanilla Forums Inc
+ * @copyright 2010-2016 Vanilla Forums Inc
  * @license Proprietary
  * @package infrastructure
  * @subpackage vfteamwork
@@ -21,7 +22,7 @@
 $ApplicationInfo['vfteamwork'] = [
     'Name' => 'Vanilla Hosting - Teamwork (ui)',
     'Description' => "Console plug-in application that provides a UI for Teamwork burndown.",
-    'Version' => '1.1',
+    'Version' => '1.1.1',
     'Author' => "Tim Gunter",
     'AuthorEmail' => 'tim@vanillaforums.com',
     'AuthorUrl' => 'http://about.me/timgunter',


### PR DESCRIPTION
Adding the parameter "ignore-start-dates" to true fixes the problem but not sure why.
Seems like a developer patch on their side to handle a change in their data structure.
